### PR TITLE
Pr/optimize

### DIFF
--- a/src/main/generated/data/laseredstone/tags/entity_type/laser_proof.json
+++ b/src/main/generated/data/laseredstone/tags/entity_type/laser_proof.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "minecraft:block_display",
+    "minecraft:item_display",
+    "minecraft:text_display",
+    "minecraft:interaction"
+  ]
+}

--- a/src/main/java/survivalblock/laseredstone/common/Laseredstone.java
+++ b/src/main/java/survivalblock/laseredstone/common/Laseredstone.java
@@ -1,13 +1,14 @@
 package survivalblock.laseredstone.common;
 
 import net.fabricmc.api.ModInitializer;
-
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import survivalblock.laseredstone.common.init.LaseredstoneBlockEntityTypes;
 import survivalblock.laseredstone.common.init.LaseredstoneBlocks;
 import survivalblock.laseredstone.common.init.LaseredstoneItems;
+import survivalblock.laseredstone.common.world.EntityUtil;
 
 public class Laseredstone implements ModInitializer {
 	public static final String MOD_ID = "laseredstone";
@@ -22,6 +23,8 @@ public class Laseredstone implements ModInitializer {
 		LaseredstoneBlocks.init();
 		LaseredstoneItems.init();
 		LaseredstoneBlockEntityTypes.init();
+
+		ServerTickEvents.END_WORLD_TICK.register(EntityUtil::damageTick);
 	}
 
 	public static Identifier id(String path) {

--- a/src/main/java/survivalblock/laseredstone/common/block/LaserBlock.java
+++ b/src/main/java/survivalblock/laseredstone/common/block/LaserBlock.java
@@ -18,6 +18,7 @@ import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.block.WireOrientation;
 import org.jetbrains.annotations.Nullable;
 import survivalblock.laseredstone.common.block.entity.LaserBlockEntity;
 import survivalblock.laseredstone.common.init.LaseredstoneBlockEntityTypes;
@@ -69,5 +70,23 @@ public class LaserBlock extends BlockWithEntity {
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
         builder.add(FACING, POWERED);
+    }
+
+    @Override
+    protected void neighborUpdate(
+            final BlockState state,
+            final World world,
+            final BlockPos pos,
+            final Block sourceBlock,
+            @Nullable final WireOrientation wireOrientation,
+            final boolean notify
+    ) {
+        if (world.isClient()) {
+            return;
+        }
+
+        // This doubles as an anti-spam measure, and a tick delay.
+        world.getBlockEntity(pos, LaseredstoneBlockEntityTypes.LASER)
+                .ifPresent(LaserBlockEntity::updateLaser);
     }
 }

--- a/src/main/java/survivalblock/laseredstone/common/block/entity/LaserBlockEntity.java
+++ b/src/main/java/survivalblock/laseredstone/common/block/entity/LaserBlockEntity.java
@@ -45,6 +45,8 @@ public class LaserBlockEntity extends LaserInteractorBlockEntity implements Beam
     protected int distance = DEFAULT_DISTANCE;
     protected int color = DEFAULT_COLOR;
 
+    protected boolean updateRequired;
+
     // for rendering
     protected @Nullable Direction currentOutputDirection = null;
 
@@ -68,12 +70,25 @@ public class LaserBlockEntity extends LaserInteractorBlockEntity implements Beam
         this.color = view.getInt("color", DEFAULT_COLOR);
     }
 
+    public void updateLaser() {
+        this.updateRequired = true;
+    }
+
     public boolean canLaser(World world, BlockPos blockPos, BlockState blockState) {
-        boolean powered = world.isReceivingRedstonePower(blockPos);
-        if (powered != blockState.get(LaserBlock.POWERED)) {
-            blockState = blockState.cycle(LaserBlock.POWERED);
-            world.setBlockState(blockPos, blockState, Block.NOTIFY_ALL);
+        final boolean statePowered = blockState.get(LaserBlock.POWERED);
+
+        if (!this.updateRequired) {
+            return statePowered;
         }
+
+        this.updateRequired = false;
+
+        final boolean powered = world.isReceivingRedstonePower(blockPos);
+
+        if (powered != statePowered) {
+            world.setBlockState(blockPos, blockState.with(LaserBlock.POWERED, powered), Block.NOTIFY_LISTENERS);
+        }
+
         return powered;
     }
 

--- a/src/main/java/survivalblock/laseredstone/common/datagen/LaseredstoneDataGenerator.java
+++ b/src/main/java/survivalblock/laseredstone/common/datagen/LaseredstoneDataGenerator.java
@@ -4,6 +4,7 @@ import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.damage.DamageType;
 import net.minecraft.registry.RegistryBuilder;
 import net.minecraft.registry.RegistryKeys;
@@ -57,6 +58,17 @@ public class LaseredstoneDataGenerator implements DataGeneratorEntrypoint {
 
 				builder(LaseredstoneTags.BYPASSES_CREATIVE_MODE)
 						.add(LaseredstoneDamageTypes.LASER);
+			}
+		});
+		pack.addProvider((fabricDataOutput, completableFuture) -> new FabricTagProvider.EntityTypeTagProvider(fabricDataOutput, completableFuture) {
+			@Override
+			protected void configure(final RegistryWrapper.WrapperLookup wrapperLookup) {
+				valueLookupBuilder(LaseredstoneTags.LASER_PROOF).add(
+						EntityType.BLOCK_DISPLAY,
+						EntityType.ITEM_DISPLAY,
+						EntityType.TEXT_DISPLAY,
+						EntityType.INTERACTION
+				);
 			}
 		});
 		pack.addProvider(LaseredstoneLootTableGenerator::new);

--- a/src/main/java/survivalblock/laseredstone/common/init/LaseredstoneTags.java
+++ b/src/main/java/survivalblock/laseredstone/common/init/LaseredstoneTags.java
@@ -1,6 +1,7 @@
 package survivalblock.laseredstone.common.init;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.damage.DamageType;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
@@ -12,4 +13,6 @@ public class LaseredstoneTags {
     public static final TagKey<Block> ALWAYS_ALLOWS_LASERS = TagKey.of(RegistryKeys.BLOCK, Laseredstone.id("always_allows_lasers"));
 
     public static final TagKey<DamageType> BYPASSES_CREATIVE_MODE = TagKey.of(RegistryKeys.DAMAGE_TYPE, Laseredstone.id("bypasses_creative_mode"));
+
+    public static final TagKey<EntityType<?>> LASER_PROOF = TagKey.of(RegistryKeys.ENTITY_TYPE, Laseredstone.id("laser_proof"));
 }

--- a/src/main/java/survivalblock/laseredstone/common/world/EntityUtil.java
+++ b/src/main/java/survivalblock/laseredstone/common/world/EntityUtil.java
@@ -1,0 +1,123 @@
+package survivalblock.laseredstone.common.world;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Box;
+import survivalblock.laseredstone.common.block.entity.LaserBlockEntity;
+import survivalblock.laseredstone.common.init.LaseredstoneDamageTypes;
+import survivalblock.laseredstone.common.init.LaseredstoneTags;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author Ampflower
+ **/
+public final class EntityUtil {
+
+	/**
+	 * Maintain a list of boxes that are currently actively damaging entities.
+	 *
+	 * @implNote ThreadLocal in use for DimThread support.
+	 */
+	private static final ThreadLocal<Set<Box>> damagingBoxes = ThreadLocal.withInitial(HashSet::new);
+
+	public static void submitDamagingBox(final Box box) {
+		damagingBoxes.get().add(box);
+	}
+
+	public static void damageTick(final ServerWorld world) {
+		final Set<Box> boxes = damagingBoxes.get();
+		if (boxes.isEmpty()) {
+			return;
+		}
+
+		final Collection<Entity> entities = getVulnerableCandidates(world);
+		if (entities.isEmpty()) {
+			return;
+		}
+
+		DamageSource source = new DamageSource(LaseredstoneDamageTypes.getFromWorld(world, LaseredstoneDamageTypes.LASER));
+
+		final Box[] boxArray = boxes.toArray(Box[]::new);
+
+		final Box filter = encompassing(boxes);
+
+		for (final Entity entity : entities) {
+			final Box bounding = entity.getBoundingBox();
+			// Low-pass filter.
+			if (!bounding.intersects(filter)) {
+				continue;
+			}
+
+			for (final Box box : boxArray) {
+				if (!bounding.intersects(box)) {
+					continue;
+				}
+				entity.damage(world, source, LaserBlockEntity.getDamage(entity));
+				break;
+			}
+		}
+
+		boxes.clear();
+	}
+
+	private static Box encompassing(final Iterable<Box> boxes) {
+		final Iterator<Box> itr = boxes.iterator();
+		final Box first = itr.next();
+
+		if (!itr.hasNext()) {
+			return first;
+		}
+
+		double minX = first.minX;
+		double minY = first.minY;
+		double minZ = first.minZ;
+		double maxX = first.maxX;
+		double maxY = first.maxY;
+		double maxZ = first.maxZ;
+
+		while (itr.hasNext()) {
+			final Box box = itr.next();
+			minX = Math.min(minX, box.minX);
+			minY = Math.min(minY, box.minY);
+			minZ = Math.min(minZ, box.minZ);
+			maxX = Math.max(maxX, box.maxX);
+			maxY = Math.max(maxY, box.maxY);
+			maxZ = Math.max(maxZ, box.maxZ);
+		}
+
+		return new Box(
+				minX,
+				minY,
+				minZ,
+				maxX,
+				maxY,
+				maxZ
+		);
+	}
+
+	private static Collection<Entity> getVulnerableCandidates(final ServerWorld world) {
+		final ArrayList<Entity> list = new ArrayList<>();
+
+		for (final Entity entity : world.iterateEntities()) {
+			if (EntityUtil.isVulnerableCandidate(entity)) {
+				list.add(entity);
+			}
+		}
+
+		return list;
+	}
+
+	public static boolean isVulnerableCandidate(final Entity entity) {
+		return entity != null
+				&& !entity.isInvulnerable()
+				&& !entity.getType().isIn(LaseredstoneTags.LASER_PROOF)
+				// && !invulnerableEntities.contains(entity.getType())
+				&& entity.isAlive();
+	}
+}


### PR DESCRIPTION
Most of the relevant optimizations as I can. There's some fruit hanging, but said fruits are already pretty fast with 1.3K entities in world.

Does change the behavior slightly; i.e. being in the intersection of a beam only damages once per tick. Can be changed by removing `break;` in the damage tick function.